### PR TITLE
Add theme toggle checkbox for light/dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ users of Visual Studio Code, there is also a dedicated extension available at
 ## Features
 
 - Live Preview: Instantly see your Markdown changes reflected in the browser.
+- Theme toggle for switching between light and dark mode.
 
 ### Built with Goldmark
 
@@ -226,7 +227,7 @@ name = "markdown"
 
 [language-server.mpls]
 command = "mpls"
-args = ["--dark-mode", "--enable-emoji"]
+args = ["--enable-emoji"]
 # An example args entry showing how to specify flags with values:
 # args = ["--port", "8080", "--browser", "google-chrome"]
 ```
@@ -254,7 +255,7 @@ return {
           if not configs.mpls then
             configs.mpls = {
               default_config = {
-                cmd = { "mpls", "--dark-mode", "--enable-emoji" },
+                cmd = { "mpls", "--enable-emoji" },
                 filetypes = { "markdown" },
                 single_file_support = true,
                 root_dir = function(startpath)
@@ -345,7 +346,6 @@ live preview of markdown files in your browser while you edit them in your favor
                                         (or (executable-find lsp-mpls-server-command)
                                             (lsp-package-path 'mpls)
                                             "mpls")
-                                        "--dark-mode"
                                         "--enable-emoji"
                                         )))
                     :activation-fn (lsp-activate-on "markdown")

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -36,7 +36,6 @@ func Execute() {
 func init() {
 	command.Flags().StringVar(&previewserver.Browser, "browser", "", "Specify the web browser to use for the preview")
 	command.Flags().StringVar(&parser.CodeHighlightingStyle, "code-style", "catppuccin-mocha", "Higlighting style for code blocks")
-	command.Flags().BoolVar(&previewserver.DarkMode, "dark-mode", false, "Enable dark mode")
 	command.Flags().BoolVar(&parser.EnableEmoji, "enable-emoji", false, "Enable emoji support")
 	command.Flags().BoolVar(&parser.EnableFootnotes, "enable-footnotes", false, "Enable footnotes")
 	command.Flags().BoolVar(&parser.EnableWikiLinks, "enable-wikilinks", false, "Enable [[wiki]] style links")

--- a/internal/previewserver/previewserver.go
+++ b/internal/previewserver/previewserver.go
@@ -22,7 +22,6 @@ import (
 
 var (
 	Browser              string
-	DarkMode             bool
 	FixedPort            int
 	OpenBrowserOnStartup bool
 
@@ -77,16 +76,6 @@ func New() *Server {
 	if FixedPort > 0 {
 		port = FixedPort
 	}
-
-	theme := "colors-light.css"
-	mermaidTheme := "default"
-
-	if DarkMode {
-		theme = "colors-dark.css"
-		mermaidTheme = "dark"
-	}
-
-	indexHTML = fmt.Sprintf(indexHTML, theme, mermaidTheme)
 
 	srv := &http.Server{
 		Addr:        fmt.Sprintf(":%d", port),

--- a/internal/previewserver/web/index.html
+++ b/internal/previewserver/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="/%s" />
+    <link id="theme-stylesheet" rel="stylesheet" href="colors-light.css" />
     <link rel="stylesheet" href="/styles.css" />
     <link
       rel="stylesheet"
@@ -23,6 +23,9 @@
             <label id="pin-checkbox-label">
               <input type="checkbox" id="pin" /> Pin Preview
             </label>
+            <label>
+              <input type="checkbox" id="theme-toggle" /> Dark Mode
+            </label>
           </div>
         </div>
       </details>
@@ -34,7 +37,7 @@
     </div>
     <script type="module">
       import mermaid from "https://cdnjs.cloudflare.com/ajax/libs/mermaid/11.2.1/mermaid.esm.mjs";
-      mermaid.initialize({ startonload: false, theme: "%s" });
+      mermaid.initialize({ startonload: false, theme: "default" });
       window.mermaid = mermaid;
     </script>
     <script src="/ws.js"></script>

--- a/internal/previewserver/web/ws.js
+++ b/internal/previewserver/web/ws.js
@@ -5,6 +5,49 @@ document.addEventListener("DOMContentLoaded", () => {
   let debounceTimeout;
   let isReloading = false;
 
+  const themeToggle = document.getElementById("theme-toggle");
+  const themeStylesheet = document.getElementById("theme-stylesheet");
+
+  function setCookie(name, value, days) {
+    let expires = "";
+    if (days) {
+      const date = new Date(Date.now() + days * 864e5);
+      expires = "; expires=" + date.toUTCString();
+    }
+    document.cookie = `${name}=${encodeURIComponent(value)}${expires}; path=/; SameSite=Lax`;
+  }
+
+  function getCookie(name) {
+    const match = document.cookie.match(
+      new RegExp("(^| )" + encodeURIComponent(name) + "=([^;]*)(;|$)"),
+    );
+    return match ? decodeURIComponent(match[2]) : null;
+  }
+
+  const theme = getCookie("theme");
+  if (theme) {
+    themeStylesheet.href =
+      theme === "dark" ? "colors-dark.css" : "colors-light.css";
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: theme === "dark" ? "dark" : "default",
+    });
+
+    themeToggle.checked = theme === "dark";
+  }
+
+  themeToggle.addEventListener("change", () => {
+    const newTheme = themeToggle.checked ? "dark" : "light";
+    themeStylesheet.href =
+      newTheme === "dark" ? "colors-dark.css" : "colors-light.css";
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: newTheme === "dark" ? "dark" : "default",
+    });
+
+    setCookie("theme", newTheme, 365);
+  });
+
   function debounce(func, delay) {
     return function (...args) {
       clearTimeout(debounceTimeout);


### PR DESCRIPTION
This PR replaces the `--dark-mode` CLI flag with a checkbox in the header to toggle between light and dark mode. The selected theme is stored in a cookie, ensuring persistence across sessions.

Note: This is a breaking change. Users who previously used the `--dark-mode` CLI option will need to reconfigure `mpls` and delete the old setting.

---
This might never get merged. Since `mpls` uses random ports by default using localStorage to store the theme preferences across sessions is not an option, it has to be done with cookies (or even more complicated with indexedDb). I don't know if I want to do that. Leaving it here giving people a chance to add their views, or until I decide for myself what I want.